### PR TITLE
Support additional repos and multiple packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ variables:
       vars:
         gitlab_buildpkg_tools__rpm_deps_repos:
           - name: packetfence-devel
-            baseurl: 'http://inverse.ca/downloads/PacketFence'
+            baseurl: http://inverse.ca/downloads/PacketFence
             extra_path: devel
             gpgkey_url: https://packetfence.org/downloads/RPM-GPG-KEY-PACKETFENCE-CENTOS
           - name: gitlab-buildpkg-tools

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 gitlab_buildpkg_tools role
 ==========================
 
-Install packages from a gitlab-buildpkg-tools PPA.
+Install a [gitlab-buildpkg-tools PPA](http://orange-opensource.gitlab.io/gitlab-buildpkg-tools/)
+and packages built with [gitlab-buildpkg-tools](https://gitlab.com/Orange-OpenSource/gitlab-buildpkg-tools) in a pipeline.
+
+This role supports also installing additional repositories or packages to meet
+dependencies of built packages in pipeline.
 
 Requirements
 ------------
@@ -12,37 +16,52 @@ pipeline to install packages.
 Role Variables
 --------------
 
-| Variable                                     | Default                                                      | Comments (type)                                       |
-| ---                                          | ---                                                          | ---                                                   |
-| `gitlab_buildpkg_tools__apt_sources_dir`     | `/etc/apt/sources.list.d`                                    | Directory to store gitlab-pages.list                  |
-| `gitlab_buildpkg_tools__deb_pkgs`            | `['apt-transport-https','gnupg']`                            | List of Debian dependencies to install built packages |
-| `gitlab_buildpkg_tools__deb_pkgs`            | `['gnupg2']`                                                 | List of CentOS dependencies to install built packages |
-| `gitlab_buildpkg_tools__ci_pages_url`        | `'{{ lookup("env"), "CI_PAGES_URL" }}'`                      | URL of PPA created by gitlab-buildpkg-tools           |
-| `gitlab_buildpkg_tools__ci_pages_gpgkey_url` | `"{{ gitlab_buildpkg_tools__ci_pages_url }}/GPG_PUBLIC_KEY"` | URL of GPG key used to sign built packages            |
-| `gitlab_buildpkg_tools__ci_project_name`     | `'{{ lookup("env"), "CI_PROJECT_NAME" }}'`                   | Name of repo in GitLab                                |
-| `gitlab_buildpkg_tools__ci_built_pkg`        | `'{{ lookup("env"), "PACKAGES_NAME" }}'`                     | Packages to install                                   |
+| Variable                                    | Default                                                                      | Comments (type)                               |
+| ---                                         | ---                                                                          | ---                                           |
+| `gitlab_buildpkg_tools__ppa`                | See <defaults/main.yml>                                                      | Dict with name, url and GPG key taken from CI |
+| `gitlab_buildpkg_tools__deb_deps_pkgs`      | `['apt-transport-https','gnupg']`                                            | List of Debian dependencies to install repos  |
+| `gitlab_buildpkg_tools__deb_sources_dir`    | `/etc/apt/sources.list.d`                                                    | Debian directory to store repos files         |
+| `gitlab_buildpkg_tools__deb_deps_repos`     | `[]`                                                                         | List of additional Debian repos               |
+| `gitlab_buildpkg_tools__deb_combined_repos` | `'{{ gitlab_buildpkg_tools__deb_deps_repos + gitlab_buildpkg_tools__ppa }}'` | List of Debian repos to install               |
+| `gitlab_buildpkg_tools__deb_built_pkg`      | `'{{ lookup("env"), "DEB_PACKAGES_NAME" }}'`                                 | List of Debian packages to install            |
+| `gitlab_buildpkg_tools__rpm_deps_pkgs`      | `['gnupg2']`                                                                 | List of CentOS dependencies to install repos  |
+| `gitlab_buildpkg_tools__rpm_deps_repos`     | `[]`                                                                         | List of additional CentOS repos               |
+| `gitlab_buildpkg_tools__rpm_combined_repos` | `'{{ gitlab_buildpkg_tools__rpm_deps_repos + gitlab_buildpkg_tools__ppa }}'` | List of CentOS repos to install               |
+| `gitlab_buildpkg_tools__rpm_built_pkg`      | `'{{ lookup("env", "RPM_PACKAGES_NAME") }}'`                                 | List of CentOS packages to install            |
 
 
-All variables that contains `ci` in their name should be defined in pipeline.
+Environment variables to set in a pipeline (see below):
+* `CI_PROJECT_NAME`
+* `CI_PAGES_URL`
+* `DEB_PACKAGES_NAME`
+* `RPM_PACKAGES_NAME`
+
 
 Limitations
 -----------
 
-In GitLab, you can define environment variables like `PACKAGES_NAME:` but
-theses variables can't be a YAML list or dictionnary. Consequently,
-`gitlab_buildpkg_tools__ci_built_pkg` is a scalar. This should work because
-`yum` and `apt` module support installing several packages from a scalar.
+### Mandatory GPG keys for repos ###
+
+This role will fail if a repo has no GPG key defined.
+
+### Environment Variables in .gitlab-ci.yml  ###
+
+In a `.gitlab-ci.yml` file, you can define environment variables like
+`DEB_PACKAGES_NAME:` but theses variables can't be a pure YAML list or
+dictionnary. Consequently, you need to use an inline YAML syntax.
 
 Examples
 --------
 
-### Example to install packages **inside** a CI ###
+### Example playbook to install packages **inside** of a CI with additional repos ###
+
 
   * `.gitlab-ci.yml`:
 
 ```yaml
 variables:
-  PACKAGES_NAME: fingerbank
+  DEB_PACKAGES_NAME: "['fingerbank', 'apt-add-gitlab', 'gitlab-buildpkg-tools']"
+  RPM_PACKAGES_NAME: "['fingerbank', 'yum-add-gitlab', 'gitlab-buildpkg-tools']"
 ```
 
   * example playbook:
@@ -51,22 +70,29 @@ variables:
 - name: example usage of inverse-inc.gitlab_buildpkg_tools role
   hosts: all
   roles:
-    - inverse-inc.gitlab_buildpkg_tools
-```
-
-
-### Example playbook to install packages **outside** of a CI ###
-
-
-```yaml
-- name: example usage of inverse-inc.gitlab_buildpkg_tools role
-  hosts: all
-  roles:
     - role: inverse-inc.gitlab_buildpkg_tools
       vars:
-        gitlab_buildpkg_tools__ci_pages_url: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools
-        gitlab_buildpkg_tools__ci_project_name: gitlab-buildpkg-tools
-        gitlab_buildpkg_tools__ci_built_pkg: gitlab-buildpkg-tools
+        gitlab_buildpkg_tools__rpm_deps_repos:
+          - name: packetfence-devel
+            baseurl: 'http://inverse.ca/downloads/PacketFence'
+            extra_path: devel
+            gpgkey_url: https://packetfence.org/downloads/RPM-GPG-KEY-PACKETFENCE-CENTOS
+          - name: gitlab-buildpkg-tools
+            baseurl: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools
+            gpgkey_url: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools/GPG_PUBLIC_KEY
+        gitlab_buildpkg_tools__deb_deps_repos:
+          - name: packetfence-devel
+            baseurl: http://inverse.ca/downloads/PacketFence
+            gpgkey_url: http://inverse.ca/downloads/APT-GPG-KEY-PACKETFENCE-DEBIAN
+            extra_path: debian-devel
+            pool: stretch
+          - name: packetfence
+            baseurl: http://inverse.ca/downloads/PacketFence
+            gpgkey_url: http://inverse.ca/downloads/APT-GPG-KEY-PACKETFENCE-DEBIAN
+            pool: stretch
+          - name: gitlab-buildpkg-tools
+            baseurl: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools
+            gpgkey_url: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools/GPG_PUBLIC_KEY
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,19 +1,27 @@
 ---
-# defaults file for gitlab_buildpkg_tools
+## Common
+gitlab_buildpkg_tools__ppa:
+  - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
+    baseurl: '{{ lookup("env", "CI_PAGES_URL") }}'
+    gpgkey_url: '{{ lookup("env", "CI_PAGES_URL") + "/GPG_PUBLIC_KEY" }}'
+
 ## Debian
-gitlab_buildpkg_tools__apt_sources_dir: /etc/apt/sources.list.d
-gitlab_buildpkg_tools__deb_pkgs:
+gitlab_buildpkg_tools__deb_deps_pkgs:
   - apt-transport-https
   - gnupg
 
+gitlab_buildpkg_tools__deb_sources_dir: /etc/apt/sources.list.d
+gitlab_buildpkg_tools__deb_deps_repos: []
+gitlab_buildpkg_tools__deb_combined_repos: '{{ gitlab_buildpkg_tools__deb_deps_repos +
+                                               gitlab_buildpkg_tools__ppa }}'
+gitlab_buildpkg_tools__deb_built_pkg: '{{ lookup("env", "DEB_PACKAGES_NAME") }}'
+
 ## CentOS
-gitlab_buildpkg_tools__rpm_pkgs:
+gitlab_buildpkg_tools__rpm_deps_pkgs:
   - gnupg2
+
+gitlab_buildpkg_tools__rpm_deps_repos: []
+gitlab_buildpkg_tools__rpm_combined_repos: '{{ gitlab_buildpkg_tools__rpm_deps_repos +
+                                               gitlab_buildpkg_tools__ppa }}'
+gitlab_buildpkg_tools__rpm_built_pkg: '{{ lookup("env", "RPM_PACKAGES_NAME") }}'
   
-## Common
-# variables defined for CI
-# can be override by inventory to use outside CI
-gitlab_buildpkg_tools__ci_pages_url: '{{ lookup("env", "CI_PAGES_URL") }}'
-gitlab_buildpkg_tools__ci_pages_gpgkey_url: "{{ gitlab_buildpkg_tools__ci_pages_url }}/GPG_PUBLIC_KEY"
-gitlab_buildpkg_tools__ci_project_name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
-gitlab_buildpkg_tools__ci_built_pkg: '{{ lookup("env", "PACKAGES_NAME") }}'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,9 +16,9 @@ galaxy_info:
 
   galaxy_tags:
     - gitlab
-    - gitlab-buildpkg-tools
+    - buildpkg
+    - build
     - pipeline
 
 
 dependencies: []
-  

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,22 +1,29 @@
 ---
-- name: install dependencies to install packages from repo
+- name: install dependencies to install packages from repos
   apt:
-    name: "{{ gitlab_buildpkg_tools__deb_pkgs }}"
-    state: latest
-    
-- name: add public key
-  apt_key:
-    url: "{{ gitlab_buildpkg_tools__ci_pages_gpgkey_url }}"
+    name: "{{ gitlab_buildpkg_tools__deb_deps_pkgs }}"
     state: present
     
-- name: install {{ gitlab_buildpkg_tools__ci_project_name }} repo from gitlab pages
-  template:
-    src: gitlab-pages.j2
-    dest: "{{ gitlab_buildpkg_tools__apt_sources_dir }}/gitlab-pages.list"
+- name: add public keys
+  apt_key:
+    url: "{{ item['gpgkey_url'] }}"
+    state: present
+  loop: "{{ gitlab_buildpkg_tools__deb_combined_repos }}"
+  loop_control:
+    label: "{{ item['gpgkey_url'] }}"
     
-# to take new key and repo(s) into account
-- name: install package from repo
+- name: install repos
+  template:
+    src: sources.list.j2
+    dest: "{{ gitlab_buildpkg_tools__deb_sources_dir }}/{{ item['name'] }}.list"
+  loop: "{{ gitlab_buildpkg_tools__deb_combined_repos }}"
+  loop_control:
+    label: "{{ item['name'] }}"
+    
+# update_cache to take new key(s) and repo(s) into account
+# latest to ensure we always install latest builds
+- name: install packages from Debian repos
   apt:
-    name: "{{ gitlab_buildpkg_tools__ci_built_pkg }}"
+    name: "{{ gitlab_buildpkg_tools__deb_built_pkg }}"
     update_cache: yes
     state: latest

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,28 +1,34 @@
 ---
-- name: install dependencies to install packages from repo
+- name: install dependencies to install packages from repos
   yum:
-    name: "{{ gitlab_buildpkg_tools__rpm_pkgs }}"
-    state: latest
-
-- name: add public key
-  rpm_key: 
+    name: "{{ gitlab_buildpkg_tools__rpm_deps_pkgs }}"
     state: present
-    key: "{{ gitlab_buildpkg_tools__ci_pages_gpgkey_url }}"
 
-- name: install {{ gitlab_buildpkg_tools__ci_project_name }} repo from gitlab pages
+- name: add public keys
+  rpm_key: 
+    key: "{{ item['gpgkey_url'] }}"
+    state: present
+  loop: "{{ gitlab_buildpkg_tools__rpm_combined_repos }}"
+  loop_control:
+    label: "{{ item['gpgkey_url'] }}"
+
+- name: install repos
   yum_repository:
-    name: "{{ gitlab_buildpkg_tools__ci_project_name }}"
-    description: "{{ gitlab_buildpkg_tools__ci_project_name }} repo"
-    baseurl: "{{ gitlab_buildpkg_tools__ci_pages_url }}/centos/$releasever/$basearch"
+    name: "{{ item['name'] }}"
+    description: "{{ item['name'] }} repo"
+    baseurl: "{{ item['baseurl'] }}/centos/$releasever/{{ item['extra_path'] | d() }}/$basearch"
     enabled: yes
     gpgcheck: yes
-    gpgkey: "{{ gitlab_buildpkg_tools__ci_pages_gpgkey_url }}"
     metadata_expire: "900"
     skip_if_unavailable: no
     repo_gpgcheck: no
+  loop: "{{ gitlab_buildpkg_tools__rpm_combined_repos }}"
+  loop_control:
+    label: "{{ item['name'] }}"
 
-- name: install package from repo
+# latest to ensure we always install latest builds
+- name: install packages from RPM repos
   yum:
-    name: "{{ gitlab_buildpkg_tools__ci_built_pkg }}"
+    name: "{{ gitlab_buildpkg_tools__rpm_built_pkg }}"
     update_cache: yes
     state: latest

--- a/templates/gitlab-pages.j2
+++ b/templates/gitlab-pages.j2
@@ -1,3 +1,0 @@
-{{ ansible_managed | comment }}
-deb [arch=amd64] {{ gitlab_buildpkg_tools__ci_pages_url }}/debian {{ ansible_lsb.codename }} main
-

--- a/templates/sources.list.j2
+++ b/templates/sources.list.j2
@@ -1,0 +1,3 @@
+{{ ansible_managed | comment }}
+deb [arch=amd64] {{ item['baseurl'] }}/{{ item['extra_path'] | d("debian") }} {{ ansible_distribution_release }} {{ item['pool'] | d("main") }}
+


### PR DESCRIPTION
This PR adds support for:
* installing additional repositories if needed to install built packages in the pipeline
* installing several packages in the pipeline
* installing packages with different names (Debian/CentOS)