### PR TITLE
Redesign of role to use it to build Packer images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@
 stages:
   - test_ppa
   - test_additional
+  - test_ppa_and_additional
 
 ### VARIABLES
 variables:
@@ -26,7 +27,7 @@ variables:
     DEB_PACKAGES_NAME: "['apt-add-gitlab', 'gitlab-buildpkg-tools']"
     RPM_PACKAGES_NAME: "['yum-add-gitlab', 'gitlab-buildpkg-tools']"
 
-.tpl_test_ppa: &test_additional
+.tpl_test_additional: &test_additional
   stage: test_additional
   variables:
     MOLECULE_PLAYBOOK:
@@ -45,7 +46,7 @@ before_script:
   - mv ansible-role- $ROLE_NAMESPACE.$ROLE_NAME
   - cd $ROLE_NAMESPACE.$ROLE_NAME
 
-# TEST PPA JOBS
+#### TEST PPA JOBS
 debian9_test_ppa:
   <<: *common
   <<: *test_ppa
@@ -67,14 +68,14 @@ centos7_test_additional:
     MOLECULE_DISTRO: centos
     MOLECULE_IMAGE_TAG: 7
 
-centos8_test_additional:
-  <<: *common
-  <<: *test_additional
-  variables:
-    MOLECULE_DISTRO: centos
-    MOLECULE_IMAGE_TAG: 8
+# centos8_test_additional:
+#   <<: *common
+#   <<: *test_additional
+#   variables:
+#     MOLECULE_DISTRO: centos
+#     MOLECULE_IMAGE_TAG: 8
 
-# TEST ADDITIONAL JOBS
+#### TEST ADDITIONAL JOBS
 debian9_test_additional:
   <<: *common
   <<: *test_additional
@@ -96,15 +97,15 @@ centos7_test_additional:
     MOLECULE_DISTRO: centos
     MOLECULE_IMAGE_TAG: 7
 
-centos8_test_additional:
-  <<: *common
-  <<: *test_additional
-  variables:
-    MOLECULE_DISTRO: centos
-    MOLECULE_IMAGE_TAG: 8
+# centos8_test_additional:
+#   <<: *common
+#   <<: *test_additional
+#   variables:
+#     MOLECULE_DISTRO: centos
+#     MOLECULE_IMAGE_TAG: 8
 
 
-# TEST PPA_AND_ADDITIONAL JOBS
+#### TEST PPA_AND_ADDITIONAL JOBS
 debian9_test_ppa_and_additional:
   <<: *common
   <<: *test_ppa_and_additional
@@ -126,9 +127,9 @@ centos7_test_ppa_and_additional:
     MOLECULE_DISTRO: centos
     MOLECULE_IMAGE_TAG: 7
 
-centos8_test_ppa_and_additional:
-  <<: *common
-  <<: *test_ppa_and_additional
-  variables:
-    MOLECULE_DISTRO: centos
-    MOLECULE_IMAGE_TAG: 8
+# centos8_test_ppa_and_additional:
+#   <<: *common
+#   <<: *test_ppa_and_additional
+#   variables:
+#     MOLECULE_DISTRO: centos
+#     MOLECULE_IMAGE_TAG: 8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,134 @@
+---
+### COMMON PARAMETERS
+
+### STAGES
+stages:
+  - test_ppa
+  - test_additional
+
+### VARIABLES
+variables:
+  ROLE_NAMESPACE: inverse-inc
+  ROLE_NAME: gitlab-buildpkg-tools
+
+### TEMPLATES
+.tpl_common: &common
+  image: geerlingguy/docker-debian10-ansible:latest
+  script:
+    - pip install molecule[docker]
+    - molecule test
+
+.tpl_test_ppa: &test_ppa
+  stage: test_ppa
+  variables:
+    CI_PROJECT_NAME: gitlab-buildpkg-tools
+    CI_PAGES_URL: http://orange-opensource.gitlab.io
+    DEB_PACKAGES_NAME: "['apt-add-gitlab', 'gitlab-buildpkg-tools']"
+    RPM_PACKAGES_NAME: "['yum-add-gitlab', 'gitlab-buildpkg-tools']"
+
+.tpl_test_ppa: &test_additional
+  stage: test_additional
+  variables:
+    MOLECULE_PLAYBOOK:
+
+.tpl_test_ppa_and_additional: &test_ppa_and_additional
+  stage: test_ppa_and_additional
+  variables:
+    CI_PROJECT_NAME: gitlab-buildpkg-tools
+    CI_PAGES_URL: http://orange-opensource.gitlab.io
+    MOLECULE_PLAYBOOK: playbook-additional.yml
+
+### JOBS
+before_script:
+  # Use actual Ansible Galaxy role name for the project directory.
+  - cd ../
+  - mv ansible-role- $ROLE_NAMESPACE.$ROLE_NAME
+  - cd $ROLE_NAMESPACE.$ROLE_NAME
+
+# TEST PPA JOBS
+debian9_test_ppa:
+  <<: *common
+  <<: *test_ppa
+  variables:
+    MOLECULE_DISTRO: debian
+    MOLECULE_IMAGE_TAG: 9
+
+debian10_test_ppa:
+  <<: *common
+  <<: *test_ppa
+  variables:
+    MOLECULE_DISTRO: debian
+    MOLECULE_IMAGE_TAG: 10
+  
+centos7_test_additional:
+  <<: *common
+  <<: *test_additional
+  variables:
+    MOLECULE_DISTRO: centos
+    MOLECULE_IMAGE_TAG: 7
+
+centos8_test_additional:
+  <<: *common
+  <<: *test_additional
+  variables:
+    MOLECULE_DISTRO: centos
+    MOLECULE_IMAGE_TAG: 8
+
+# TEST ADDITIONAL JOBS
+debian9_test_additional:
+  <<: *common
+  <<: *test_additional
+  variables:
+    MOLECULE_DISTRO: debian
+    MOLECULE_IMAGE_TAG: 9
+
+debian10_test_additional:
+  <<: *common
+  <<: *test_additional
+  variables:
+    MOLECULE_DISTRO: debian
+    MOLECULE_IMAGE_TAG: 10
+  
+centos7_test_additional:
+  <<: *common
+  <<: *test_additional
+  variables:
+    MOLECULE_DISTRO: centos
+    MOLECULE_IMAGE_TAG: 7
+
+centos8_test_additional:
+  <<: *common
+  <<: *test_additional
+  variables:
+    MOLECULE_DISTRO: centos
+    MOLECULE_IMAGE_TAG: 8
+
+
+# TEST PPA_AND_ADDITIONAL JOBS
+debian9_test_ppa_and_additional:
+  <<: *common
+  <<: *test_ppa_and_additional
+  variables:
+    MOLECULE_DISTRO: debian
+    MOLECULE_IMAGE_TAG: 9
+
+debian10_test_ppa_and_additional:
+  <<: *common
+  <<: *test_ppa_and_additional
+  variables:
+    MOLECULE_DISTRO: debian
+    MOLECULE_IMAGE_TAG: 10
+  
+centos7_test_ppa_and_additional:
+  <<: *common
+  <<: *test_ppa_and_additional
+  variables:
+    MOLECULE_DISTRO: centos
+    MOLECULE_IMAGE_TAG: 7
+
+centos8_test_ppa_and_additional:
+  <<: *common
+  <<: *test_ppa_and_additional
+  variables:
+    MOLECULE_DISTRO: centos
+    MOLECULE_IMAGE_TAG: 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `gitlab_buildpkg_tools__rpm_built_pkg` renamed to
   `gitlab_buildpkg_tools__deb_pkgs` and `gitlab_buildpkg_tools__rpm_pkgs`
 - Documentation of variables
+- Use state `present` in place of `latest` for packages installations
 
 ### Removed
 - Variable `gitlab_buildpkg_tools__ppa`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `gitlab_buildpkg_tools__deb_ppa_enabled`
 - Allow to install any repos or any GPG keys without any relation between them
 - Simplify installation of repos
+- GitLab pipeline to test roles using molecule
 
 ### Changed
 - `gpgkey_url` renamed to `gpgkey`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `gpgkey_url` renamed to `gpgkey`
+- `gitlab_buildpkg_tools__deb_built_pkg` and
+  `gitlab_buildpkg_tools__rpm_built_pkg` renamed to
+  `gitlab_buildpkg_tools__deb_pkgs` and `gitlab_buildpkg_tools__rpm_pkgs`
 - Documentation of variables
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Molecule tests to test this role on several OS
+- Enable PPA only if running in a pipeline with
+  `gitlab_buildpkg_tools__deb_ppa_enabled`
+- Allow to install any repos or any GPG keys without any relation between them
+- Simplify installation of repos
+
+### Changed
+- `gpgkey_url` renamed to `gpgkey`
+- Documentation of variables
+
+### Removed
+- Variable `gitlab_buildpkg_tools__ppa`
+- Variable `extra_path` and `pool`  for CentOS and Debian repos
+
+### Fixed
+- Role name in example playbook
+
+
+[Unreleased]: https://github.com/inverse-inc/ansible-role-gitlab-buildpkg-tools/compare/v0.2.0...HEAD

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Available variables are listed below, check `defaults/main.yml` for defaults val
 
 Controls whether PPA repo and key should be installed.
 
+    gitlab_buildpkg_tools__ppa_url
+    
+Full URL of the PPA.
+
     gitlab_buildpkg_tools__deb_ppa
 
 Debian PPA repo parameters.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,16 @@ Available variables are listed below, check `defaults/main.yml` for defaults val
 Controls whether PPA repo and key should be installed.
 
     gitlab_buildpkg_tools__ppa_url
-    
-Full URL of the PPA.
+
+URL of the PPA.
+
+    gitlab_buildpkg_tools__ppa_url_deb
+
+URL of the PPA with Debian part.
+
+    gitlab_buildpkg_tools__ppa_url_deb
+
+URL of the PPA with CentOS part.
 
     gitlab_buildpkg_tools__deb_ppa
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 gitlab_buildpkg_tools role
 ==========================
 
+[![pipeline status](https://gitlab.com/inverse-inc/ansible-role-gitlab-buildpkg-tools/badges/master/pipeline.svg)](https://gitlab.com/inverse-inc/ansible-role-gitlab-buildpkg-tools/commits/master)
+
 Install a [gitlab-buildpkg-tools PPA](http://orange-opensource.gitlab.io/gitlab-buildpkg-tools/)
 and packages built with [gitlab-buildpkg-tools](https://gitlab.com/Orange-OpenSource/gitlab-buildpkg-tools) in a pipeline.
 

--- a/README.md
+++ b/README.md
@@ -119,47 +119,30 @@ dictionnary. Consequently, you need to use an inline YAML syntax.
 Examples
 --------
 
-### Example playbook to install packages **inside** of a CI with additional repos ###
+### Example to install packages **inside** of a CI  ###
 
 
   * `.gitlab-ci.yml`:
 
 ```yaml
 variables:
-  DEB_PACKAGES_NAME: "['fingerbank', 'apt-add-gitlab', 'gitlab-buildpkg-tools']"
-  RPM_PACKAGES_NAME: "['fingerbank', 'yum-add-gitlab', 'gitlab-buildpkg-tools']"
+  DEB_PACKAGES_NAME: "['apt-add-gitlab', 'gitlab-buildpkg-tools']"
+  RPM_PACKAGES_NAME: "['yum-add-gitlab', 'gitlab-buildpkg-tools']"
+  CI_PROJECT_NAME: gitlab-buildpkg-tools
+  CI_PAGES_URL: http://orange-opensource.gitlab.io
 ```
 
-  * example playbook:
+Of course, if you use this playbook inside a pipeline where
+`gitlab-buildpkg-tools` is used, you don't need to define `CI_PROJECT_NAME`
+and `CI_PAGES_URL` variables.
 
-```yaml
-- name: example usage of inverse_inc.gitlab_buildpkg_tools role
-  hosts: all
-  roles:
-    - role: inverse_inc.gitlab_buildpkg_tools
-      vars:
-        gitlab_buildpkg_tools__rpm_deps_repos:
-          - name: packetfence-devel
-            baseurl: http://inverse.ca/downloads/PacketFence
-            extra_path: devel
-            gpgkey_url: https://packetfence.org/downloads/RPM-GPG-KEY-PACKETFENCE-CENTOS
-          - name: gitlab-buildpkg-tools
-            baseurl: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools
-            gpgkey_url: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools/GPG_PUBLIC_KEY
-        gitlab_buildpkg_tools__deb_deps_repos:
-          - name: packetfence-devel
-            baseurl: http://inverse.ca/downloads/PacketFence
-            gpgkey_url: http://inverse.ca/downloads/APT-GPG-KEY-PACKETFENCE-DEBIAN
-            extra_path: debian-devel
-            pool: stretch
-          - name: packetfence
-            baseurl: http://inverse.ca/downloads/PacketFence
-            gpgkey_url: http://inverse.ca/downloads/APT-GPG-KEY-PACKETFENCE-DEBIAN
-            pool: stretch
-          - name: gitlab-buildpkg-tools
-            baseurl: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools
-            gpgkey_url: https://orange-opensource.gitlab.io/gitlab-buildpkg-tools/GPG_PUBLIC_KEY
-```
+  * example playbook: see [playbook.yml use for molecule tests](molecule/default/playbook.yml)
+
+
+### Example to install packages with additional repos and keys ###
+
+See [playbook-additional.yml use for molecule
+tests](molecule/default/playbook-additional.yml).
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ gitlab_buildpkg_tools role
 Install a [gitlab-buildpkg-tools PPA](http://orange-opensource.gitlab.io/gitlab-buildpkg-tools/)
 and packages built with [gitlab-buildpkg-tools](https://gitlab.com/Orange-OpenSource/gitlab-buildpkg-tools) in a pipeline.
 
-This role supports also installing additional repositories or packages to meet
+This role supports also installing additional repositories, GPG keys or packages to meet
 dependencies of built packages in pipeline.
 
 Requirements
 ------------
 
-Role designed to be launch in a GitLab pipeline but can be called outside a
-pipeline to install packages.
+Role designed to be launch in a GitLab pipeline. It can be called outside a
+pipeline but you will need to set some variables by hand.
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -16,18 +16,71 @@ pipeline to install packages.
 Role Variables
 --------------
 
-| Variable                                    | Default                                                                      | Comments (type)                               |
-| ---                                         | ---                                                                          | ---                                           |
-| `gitlab_buildpkg_tools__ppa`                | See <defaults/main.yml>                                                      | Dict with name, url and GPG key taken from CI |
-| `gitlab_buildpkg_tools__deb_deps_pkgs`      | `['apt-transport-https','gnupg']`                                            | List of Debian dependencies to install repos  |
-| `gitlab_buildpkg_tools__deb_sources_dir`    | `/etc/apt/sources.list.d`                                                    | Debian directory to store repos files         |
-| `gitlab_buildpkg_tools__deb_deps_repos`     | `[]`                                                                         | List of additional Debian repos               |
-| `gitlab_buildpkg_tools__deb_combined_repos` | `'{{ gitlab_buildpkg_tools__deb_deps_repos + gitlab_buildpkg_tools__ppa }}'` | List of Debian repos to install               |
-| `gitlab_buildpkg_tools__deb_built_pkg`      | `'{{ lookup("env"), "DEB_PACKAGES_NAME" }}'`                                 | List of Debian packages to install            |
-| `gitlab_buildpkg_tools__rpm_deps_pkgs`      | `['gnupg2']`                                                                 | List of CentOS dependencies to install repos  |
-| `gitlab_buildpkg_tools__rpm_deps_repos`     | `[]`                                                                         | List of additional CentOS repos               |
-| `gitlab_buildpkg_tools__rpm_combined_repos` | `'{{ gitlab_buildpkg_tools__rpm_deps_repos + gitlab_buildpkg_tools__ppa }}'` | List of CentOS repos to install               |
-| `gitlab_buildpkg_tools__rpm_built_pkg`      | `'{{ lookup("env", "RPM_PACKAGES_NAME") }}'`                                 | List of CentOS packages to install            |
+Available variables are listed below, check `defaults/main.yml` for defaults values:
+
+    gitlab_buildpkg_tools__ppa_enabled
+
+Controls whether PPA repo and key should be installed.
+
+    gitlab_buildpkg_tools__deb_ppa
+
+Debian PPA repo parameters.
+
+    gitlab_buildpkg_tools__rpm_ppa
+
+RPM PPA repo parameters.
+
+    gitlab_buildpkg_tools__deb_deps_pkgs
+
+List of Debian dependencies to install repos.
+
+    gitlab_buildpkg_tools__deb_keys
+
+List of GPG keys **URL**.
+
+    gitlab_buildpkg_tools__deb_combined_keys
+
+List of GPG keys to install (PPA + additional).
+
+    gitlab_buildpkg_tools__deb_sources_dir
+
+Debian directory to store repos files.
+
+    gitlab_buildpkg_tools__deb_deps_repos
+
+List of additional Debian repos.
+
+    gitlab_buildpkg_tools__deb_combined_repos
+
+List of Debian repos to install.
+
+    gitlab_buildpkg_tools__deb_pkgs
+
+List of Debian packages to install.
+
+    gitlab_buildpkg_tools__rpm_deps_pkgs
+
+List of CentOS dependencies to install repos.
+
+    gitlab_buildpkg_tools__rpm_keys
+
+List of GPG keys URL or files.
+
+    gitlab_buildpkg_tools__rpm_combined_keys
+
+List of GPG keys to install (PPA + additional).
+
+    gitlab_buildpkg_tools__rpm_deps_repos
+
+List of additional CentOS repos.
+
+    gitlab_buildpkg_tools__rpm_combined_repos
+
+List of CentOS repos to install.
+
+    gitlab_buildpkg_tools__rpm_pkgs
+
+List of CentOS packages to install.
 
 
 Environment variables to set in a pipeline (see below):
@@ -40,9 +93,10 @@ Environment variables to set in a pipeline (see below):
 Limitations
 -----------
 
-### Mandatory GPG keys for repos ###
+### Debian limitations ###
 
-This role will fail if a repo has no GPG key defined.
+- GPG keys need to be added by URL
+- Debian packages need to be installed by name
 
 ### Environment Variables in .gitlab-ci.yml  ###
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 ## Common
+gitlab_buildpkg_tools__ppa_enabled: '{{ True if lookup("env", "CI_PAGES_URL")
+                                             else False }}'
 gitlab_buildpkg_tools__ppa:
   - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
     baseurl: '{{ lookup("env", "CI_PAGES_URL") }}'
@@ -13,7 +15,9 @@ gitlab_buildpkg_tools__deb_deps_pkgs:
 gitlab_buildpkg_tools__deb_sources_dir: /etc/apt/sources.list.d
 gitlab_buildpkg_tools__deb_deps_repos: []
 gitlab_buildpkg_tools__deb_combined_repos: '{{ gitlab_buildpkg_tools__deb_deps_repos +
-                                               gitlab_buildpkg_tools__ppa }}'
+                                               (gitlab_buildpkg_tools__ppa
+                                                if gitlab_buildpkg_tools__ppa_enabled
+                                                else []) }}'
 gitlab_buildpkg_tools__deb_built_pkg: '{{ lookup("env", "DEB_PACKAGES_NAME") }}'
 
 ## CentOS
@@ -22,6 +26,8 @@ gitlab_buildpkg_tools__rpm_deps_pkgs:
 
 gitlab_buildpkg_tools__rpm_deps_repos: []
 gitlab_buildpkg_tools__rpm_combined_repos: '{{ gitlab_buildpkg_tools__rpm_deps_repos +
-                                               gitlab_buildpkg_tools__ppa }}'
+                                               (gitlab_buildpkg_tools__ppa
+                                                if gitlab_buildpkg_tools__ppa_enabled
+                                                else []) }}'
 gitlab_buildpkg_tools__rpm_built_pkg: '{{ lookup("env", "RPM_PACKAGES_NAME") }}'
-  
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,15 +4,17 @@ gitlab_buildpkg_tools__ppa_enabled: '{{ True if lookup("env", "CI_PAGES_URL")
                                              else False }}'
 
 gitlab_buildpkg_tools__ppa_url: '{{ lookup("env", "CI_PAGES_URL") + "/" + lookup("env", "CI_PROJECT_NAME") }}'
+gitlab_buildpkg_tools__ppa_url_deb: '{{ gitlab_buildpkg_tools__ppa_url + "/debian" }}'
+gitlab_buildpkg_tools__ppa_url_rpm: '{{ gitlab_buildpkg_tools__ppa_url + "/centos" }}'
 
 gitlab_buildpkg_tools__deb_ppa:
   - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
-    baseurl: '{{ gitlab_buildpkg_tools__ppa_url + "/debian" + ansible_distribution_release + "main" }}'
+    baseurl: '{{ gitlab_buildpkg_tools__ppa_url_deb }} {{ ansible_distribution_release }} main'
     gpgkey: '{{ gitlab_buildpkg_tools__ppa_url + "/GPG_PUBLIC_KEY" }}'
 
 gitlab_buildpkg_tools__rpm_ppa:
   - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
-    baseurl: '{{ gitlab_buildpkg_tools__ppa_url  + "/centos/$releasever/$basearch" }}'
+    baseurl: '{{ gitlab_buildpkg_tools__ppa_url_rpm + "/$releasever/$basearch" }}'
     gpgkey: '{{ gitlab_buildpkg_tools__ppa_url + "/GPG_PUBLIC_KEY" }}'
 
 ## Debian

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,14 @@
 ## Common
 gitlab_buildpkg_tools__ppa_enabled: '{{ True if lookup("env", "CI_PAGES_URL")
                                              else False }}'
-gitlab_buildpkg_tools__ppa:
+gitlab_buildpkg_tools__deb_ppa:
   - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
-    baseurl: '{{ lookup("env", "CI_PAGES_URL") }}'
+    baseurl: '{{ lookup("env", "CI_PAGES_URL") + "/debian" + ansible_distribution_release + "main" }}'
+    gpgkey: '{{ lookup("env", "CI_PAGES_URL") + "/GPG_PUBLIC_KEY" }}'
+
+gitlab_buildpkg_tools__rpm_ppa:
+  - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
+    baseurl: '{{ lookup("env", "CI_PAGES_URL")  + "/centos/$releasever/$basearch" }}'
     gpgkey: '{{ lookup("env", "CI_PAGES_URL") + "/GPG_PUBLIC_KEY" }}'
 
 ## Debian
@@ -17,13 +22,13 @@ gitlab_buildpkg_tools__deb_keys: []
 
 # we use '[ ]' to merge string with a list
 gitlab_buildpkg_tools__deb_combined_keys: "{{ gitlab_buildpkg_tools__deb_keys +
-                                              ([ gitlab_buildpkg_tools__ppa[0]['gpgkey'] ]
+                                              ([ gitlab_buildpkg_tools__deb_ppa[0]['gpgkey'] ]
                                                if gitlab_buildpkg_tools__ppa_enabled|bool
                                                else []) }}"
 gitlab_buildpkg_tools__deb_sources_dir: /etc/apt/sources.list.d
 gitlab_buildpkg_tools__deb_deps_repos: []
 gitlab_buildpkg_tools__deb_combined_repos: '{{ gitlab_buildpkg_tools__deb_deps_repos +
-                                               (gitlab_buildpkg_tools__ppa
+                                               (gitlab_buildpkg_tools__deb_ppa
                                                 if gitlab_buildpkg_tools__ppa_enabled|bool
                                                 else []) }}'
 gitlab_buildpkg_tools__deb_built_pkg: '{{ lookup("env", "DEB_PACKAGES_NAME") }}'
@@ -37,12 +42,12 @@ gitlab_buildpkg_tools__rpm_keys: []
 
 # we use '[ ]' to merge string with a list
 gitlab_buildpkg_tools__rpm_combined_keys: "{{ gitlab_buildpkg_tools__rpm_keys +
-                                              ([ gitlab_buildpkg_tools__ppa[0]['gpgkey'] ]
+                                              ([ gitlab_buildpkg_tools__rpm_ppa[0]['gpgkey'] ]
                                                if gitlab_buildpkg_tools__ppa_enabled|bool
                                                else []) }}"
 gitlab_buildpkg_tools__rpm_deps_repos: []
 gitlab_buildpkg_tools__rpm_combined_repos: '{{ gitlab_buildpkg_tools__rpm_deps_repos +
-                                               (gitlab_buildpkg_tools__ppa
+                                               (gitlab_buildpkg_tools__rpm_ppa
                                                 if gitlab_buildpkg_tools__ppa_enabled|bool
                                                 else []) }}'
 gitlab_buildpkg_tools__rpm_built_pkg: '{{ lookup("env", "RPM_PACKAGES_NAME") }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,4 +51,3 @@ gitlab_buildpkg_tools__rpm_combined_repos: '{{ gitlab_buildpkg_tools__rpm_deps_r
                                                 if gitlab_buildpkg_tools__ppa_enabled|bool
                                                 else []) }}'
 gitlab_buildpkg_tools__rpm_built_pkg: '{{ lookup("env", "RPM_PACKAGES_NAME") }}'
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,6 @@ gitlab_buildpkg_tools__deb_deps_pkgs:
   - apt-transport-https
   - gnupg
 
-# list of URL
 gitlab_buildpkg_tools__deb_keys: []
 
 # we use '[ ]' to merge string with a list
@@ -31,7 +30,7 @@ gitlab_buildpkg_tools__deb_combined_repos: '{{ gitlab_buildpkg_tools__deb_deps_r
                                                (gitlab_buildpkg_tools__deb_ppa
                                                 if gitlab_buildpkg_tools__ppa_enabled|bool
                                                 else []) }}'
-gitlab_buildpkg_tools__deb_built_pkg: '{{ lookup("env", "DEB_PACKAGES_NAME") }}'
+gitlab_buildpkg_tools__deb_pkgs: '{{ lookup("env", "DEB_PACKAGES_NAME") }}'
 
 ## CentOS
 gitlab_buildpkg_tools__rpm_deps_pkgs:
@@ -50,4 +49,4 @@ gitlab_buildpkg_tools__rpm_combined_repos: '{{ gitlab_buildpkg_tools__rpm_deps_r
                                                (gitlab_buildpkg_tools__rpm_ppa
                                                 if gitlab_buildpkg_tools__ppa_enabled|bool
                                                 else []) }}'
-gitlab_buildpkg_tools__rpm_built_pkg: '{{ lookup("env", "RPM_PACKAGES_NAME") }}'
+gitlab_buildpkg_tools__rpm_pkgs: '{{ lookup("env", "RPM_PACKAGES_NAME") }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,15 +2,18 @@
 ## Common
 gitlab_buildpkg_tools__ppa_enabled: '{{ True if lookup("env", "CI_PAGES_URL")
                                              else False }}'
+
+gitlab_buildpkg_tools__ppa_url: '{{ lookup("env", "CI_PAGES_URL") + "/" + lookup("env", "CI_PROJECT_NAME") }}'
+
 gitlab_buildpkg_tools__deb_ppa:
   - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
-    baseurl: '{{ lookup("env", "CI_PAGES_URL") + "/debian" + ansible_distribution_release + "main" }}'
-    gpgkey: '{{ lookup("env", "CI_PAGES_URL") + "/GPG_PUBLIC_KEY" }}'
+    baseurl: '{{ gitlab_buildpkg_tools__ppa_url + "/debian" + ansible_distribution_release + "main" }}'
+    gpgkey: '{{ gitlab_buildpkg_tools__ppa_url + "/GPG_PUBLIC_KEY" }}'
 
 gitlab_buildpkg_tools__rpm_ppa:
   - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
-    baseurl: '{{ lookup("env", "CI_PAGES_URL")  + "/centos/$releasever/$basearch" }}'
-    gpgkey: '{{ lookup("env", "CI_PAGES_URL") + "/GPG_PUBLIC_KEY" }}'
+    baseurl: '{{ gitlab_buildpkg_tools__ppa_url  + "/centos/$releasever/$basearch" }}'
+    gpgkey: '{{ gitlab_buildpkg_tools__ppa_url + "/GPG_PUBLIC_KEY" }}'
 
 ## Debian
 gitlab_buildpkg_tools__deb_deps_pkgs:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,18 +5,26 @@ gitlab_buildpkg_tools__ppa_enabled: '{{ True if lookup("env", "CI_PAGES_URL")
 gitlab_buildpkg_tools__ppa:
   - name: '{{ lookup("env", "CI_PROJECT_NAME") }}'
     baseurl: '{{ lookup("env", "CI_PAGES_URL") }}'
-    gpgkey_url: '{{ lookup("env", "CI_PAGES_URL") + "/GPG_PUBLIC_KEY" }}'
+    gpgkey: '{{ lookup("env", "CI_PAGES_URL") + "/GPG_PUBLIC_KEY" }}'
 
 ## Debian
 gitlab_buildpkg_tools__deb_deps_pkgs:
   - apt-transport-https
   - gnupg
 
+# list of URL
+gitlab_buildpkg_tools__deb_keys: []
+
+# we use '[ ]' to merge string with a list
+gitlab_buildpkg_tools__deb_combined_keys: "{{ gitlab_buildpkg_tools__deb_keys +
+                                              ([ gitlab_buildpkg_tools__ppa[0]['gpgkey'] ]
+                                               if gitlab_buildpkg_tools__ppa_enabled|bool
+                                               else []) }}"
 gitlab_buildpkg_tools__deb_sources_dir: /etc/apt/sources.list.d
 gitlab_buildpkg_tools__deb_deps_repos: []
 gitlab_buildpkg_tools__deb_combined_repos: '{{ gitlab_buildpkg_tools__deb_deps_repos +
                                                (gitlab_buildpkg_tools__ppa
-                                                if gitlab_buildpkg_tools__ppa_enabled
+                                                if gitlab_buildpkg_tools__ppa_enabled|bool
                                                 else []) }}'
 gitlab_buildpkg_tools__deb_built_pkg: '{{ lookup("env", "DEB_PACKAGES_NAME") }}'
 
@@ -24,10 +32,18 @@ gitlab_buildpkg_tools__deb_built_pkg: '{{ lookup("env", "DEB_PACKAGES_NAME") }}'
 gitlab_buildpkg_tools__rpm_deps_pkgs:
   - gnupg2
 
+# list of URL or files
+gitlab_buildpkg_tools__rpm_keys: []
+
+# we use '[ ]' to merge string with a list
+gitlab_buildpkg_tools__rpm_combined_keys: "{{ gitlab_buildpkg_tools__rpm_keys +
+                                              ([ gitlab_buildpkg_tools__ppa[0]['gpgkey'] ]
+                                               if gitlab_buildpkg_tools__ppa_enabled|bool
+                                               else []) }}"
 gitlab_buildpkg_tools__rpm_deps_repos: []
 gitlab_buildpkg_tools__rpm_combined_repos: '{{ gitlab_buildpkg_tools__rpm_deps_repos +
                                                (gitlab_buildpkg_tools__ppa
-                                                if gitlab_buildpkg_tools__ppa_enabled
+                                                if gitlab_buildpkg_tools__ppa_enabled|bool
                                                 else []) }}'
 gitlab_buildpkg_tools__rpm_built_pkg: '{{ lookup("env", "RPM_PACKAGES_NAME") }}'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,6 @@ gitlab_buildpkg_tools__deb_pkgs: '{{ lookup("env", "DEB_PACKAGES_NAME") }}'
 gitlab_buildpkg_tools__rpm_deps_pkgs:
   - gnupg2
 
-# list of URL or files
 gitlab_buildpkg_tools__rpm_keys: []
 
 # we use '[ ]' to merge string with a list

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,22 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,10 +12,6 @@ platforms:
   - name: instance
     # allow to override docker image with env var
     image: "${MOLECULE_DISTRO:-centos}:${MOLECULE_IMAGE_TAG:-7}"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
     
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,12 +11,11 @@ lint:
 platforms:
   - name: instance
     # allow to override docker image with env var
-    image: "geerlingguy/docker-${DISTRO:-centos7}-ansible:latest"
+    image: "${MOLECULE_DISTRO:-centos}:${MOLECULE_TAG:-7}"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
-    pre_build_image: true
     
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:
 platforms:
   - name: instance
     # allow to override docker image with env var
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    image: "geerlingguy/docker-${DISTRO:-centos7}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ lint:
 platforms:
   - name: instance
     # allow to override docker image with env var
-    image: "${MOLECULE_DISTRO:-centos}:${MOLECULE_TAG:-7}"
+    image: "${MOLECULE_DISTRO:-centos}:${MOLECULE_IMAGE_TAG:-7}"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -24,7 +24,7 @@ provisioner:
   # allow to override playbook use for converge action with env var
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-playbook.yml}
-    
+
 verifier:
   name: testinfra
   lint:

--- a/molecule/default/playbook-additional.yml
+++ b/molecule/default/playbook-additional.yml
@@ -9,7 +9,7 @@
 
     gitlab_buildpkg_tools__deb_deps_repos:
       - name: lemonldap-ng
-        baseurl: 'https://lemonldap-ng.ow2.io/lemonldap-ng/ {{ ansible_distribution_release }} main'
+        baseurl: 'https://lemonldap-ng.ow2.io/lemonldap-ng/debian {{ ansible_distribution_release }} main'
 
     gitlab_buildpkg_tools__rpm_keys:
       - https://inverse-inc.gitlab.io/perl-client/GPG_PUBLIC_KEY

--- a/molecule/default/playbook-additional.yml
+++ b/molecule/default/playbook-additional.yml
@@ -1,0 +1,32 @@
+---
+- name: Converge
+  hosts: all
+  become: True
+
+  vars:
+    gitlab_buildpkg_tools__deb_keys:
+      - https://lemonldap-ng.ow2.io/lemonldap-ng/GPG_PUBLIC_KEY
+
+    gitlab_buildpkg_tools__deb_deps_repos:
+      - name: lemonldap-ng
+        baseurl: 'https://lemonldap-ng.ow2.io/lemonldap-ng/ {{ ansible_distribution_release }} main'
+
+    gitlab_buildpkg_tools__rpm_keys:
+      - https://inverse-inc.gitlab.io/perl-client/GPG_PUBLIC_KEY
+
+    gitlab_buildpkg_tools__rpm_deps_repos:
+      - name: perl-client
+        baseurl: https://inverse-inc.gitlab.io/perl-client/centos/$releasever/$basearch
+
+    gitlab_buildpkg_tools__deb_pkgs:
+      - apt-add-gitlab
+      - gitlab-buildpkg-tools
+      - lemonldap-ng
+
+    gitlab_buildpkg_tools__rpm_pkgs:
+      - yum-add-gitlab
+      - gitlab-buildpkg-tools
+      - fingerbank
+      
+  roles:
+    - role: inverse-inc.gitlab-buildpkg-tools

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   become: True
-  
+
   roles:
     - role: inverse-inc.gitlab-buildpkg-tools

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -9,7 +9,7 @@
     url: "{{ item }}"
     state: present
   loop: '{{ gitlab_buildpkg_tools__deb_combined_keys }}'
-    
+
 - name: install repos
   template:
     src: sources.list.j2
@@ -17,7 +17,7 @@
   loop: "{{ gitlab_buildpkg_tools__deb_combined_repos }}"
   loop_control:
     label: "{{ item['name'] }}"
-    
+
 # update_cache to take new key(s) and repo(s) into account
 # latest to ensure we always install latest builds
 - name: install packages from Debian repos

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,14 +3,12 @@
   apt:
     name: "{{ gitlab_buildpkg_tools__deb_deps_pkgs }}"
     state: present
-    
+
 - name: add public keys
   apt_key:
-    url: "{{ item['gpgkey_url'] }}"
+    url: "{{ item }}"
     state: present
-  loop: "{{ gitlab_buildpkg_tools__deb_combined_repos }}"
-  loop_control:
-    label: "{{ item['gpgkey_url'] }}"
+  loop: '{{ gitlab_buildpkg_tools__deb_combined_keys }}'
     
 - name: install repos
   template:

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -21,6 +21,6 @@
 # update_cache to take new key(s) and repo(s) into account
 - name: install packages from Debian repos
   apt:
-    name: "{{ gitlab_buildpkg_tools__deb_pkg }}"
+    name: "{{ gitlab_buildpkg_tools__deb_pkgs }}"
     update_cache: yes
     state: present

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -19,9 +19,8 @@
     label: "{{ item['name'] }}"
 
 # update_cache to take new key(s) and repo(s) into account
-# latest to ensure we always install latest builds
 - name: install packages from Debian repos
   apt:
     name: "{{ gitlab_buildpkg_tools__deb_pkg }}"
     update_cache: yes
-    state: latest
+    state: present

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -22,6 +22,6 @@
 # latest to ensure we always install latest builds
 - name: install packages from Debian repos
   apt:
-    name: "{{ gitlab_buildpkg_tools__deb_built_pkg }}"
+    name: "{{ gitlab_buildpkg_tools__deb_pkg }}"
     update_cache: yes
     state: latest

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -27,6 +27,7 @@
 # latest to ensure we always install latest builds
 - name: install packages from RPM repos
   yum:
-    name: "{{ gitlab_buildpkg_tools__rpm_built_pkg }}"
+    name: "{{ gitlab_buildpkg_tools__rpm_pkg }}"
     update_cache: yes
     state: latest
+

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -24,10 +24,10 @@
   loop_control:
     label: "{{ item['name'] }}"
 
-# latest to ensure we always install latest builds
+# update_cache to take new key(s) and repo(s) into account
 - name: install packages from RPM repos
   yum:
     name: "{{ gitlab_buildpkg_tools__rpm_pkg }}"
     update_cache: yes
-    state: latest
+    state: present
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -27,7 +27,6 @@
 # update_cache to take new key(s) and repo(s) into account
 - name: install packages from RPM repos
   yum:
-    name: "{{ gitlab_buildpkg_tools__rpm_pkg }}"
+    name: "{{ gitlab_buildpkg_tools__rpm_pkgs }}"
     update_cache: yes
     state: present
-

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -6,11 +6,9 @@
 
 - name: add public keys
   rpm_key: 
-    key: "{{ item['gpgkey_url'] }}"
+    key: "{{ item }}"
     state: present
-  loop: "{{ gitlab_buildpkg_tools__rpm_combined_repos }}"
-  loop_control:
-    label: "{{ item['gpgkey_url'] }}"
+  loop: "{{ gitlab_buildpkg_tools__rpm_combined_keys }}"
 
 - name: install repos
   yum_repository:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -14,7 +14,7 @@
   yum_repository:
     name: "{{ item['name'] }}"
     description: "{{ item['name'] }} repo"
-    baseurl: "{{ item['baseurl'] }}/centos/$releasever/{{ item['extra_path'] | d() }}/$basearch"
+    baseurl: "{{ item['baseurl'] }}"
     enabled: yes
     gpgcheck: yes
     metadata_expire: "900"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -5,7 +5,7 @@
     state: present
 
 - name: add public keys
-  rpm_key: 
+  rpm_key:
     key: "{{ item }}"
     state: present
   loop: "{{ gitlab_buildpkg_tools__rpm_combined_keys }}"

--- a/templates/sources.list.j2
+++ b/templates/sources.list.j2
@@ -1,3 +1,3 @@
 {{ ansible_managed | comment }}
-deb [arch=amd64] {{ item['baseurl'] }}/{{ item['extra_path'] | d("debian") }} {{ ansible_distribution_release }} {{ item['pool'] | d("main") }}
+deb [arch=amd64] {{ item['baseurl'] }}
 


### PR DESCRIPTION
- Automatically enable/disable PPA use by gitlab_buildpkg_tools
- Allow to install any repos or any GPG keys without any relation between them
- Merge PPA key with other Debian or RPM keys
- Simplify installation of repos
- GitLab pipeline
- Molecule tests in pipeline

# TODO
- [x] Update documentation