### PR TITLE
Fix wrong usage of CI_PAGES_URL in a GitLab Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,22 +10,22 @@ env:
     # Test PPA
     - MOLECULE_DISTRO=debian9
       CI_PROJECT_NAME=gitlab-buildpkg-tools
-      CI_PAGES_URL=http://orange-opensource.gitlab.io
+      CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
       DEB_PACKAGES_NAME="['apt-add-gitlab','gitlab-buildpkg-tools']"
 
     - MOLECULE_DISTRO=debian10
       CI_PROJECT_NAME=gitlab-buildpkg-tools
-      CI_PAGES_URL=http://orange-opensource.gitlab.io
+      CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
       DEB_PACKAGES_NAME="['apt-add-gitlab','gitlab-buildpkg-tools']"
 
     - MOLECULE_DISTRO=centos7
       CI_PROJECT_NAME=gitlab-buildpkg-tools
-      CI_PAGES_URL=http://orange-opensource.gitlab.io
+      CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
       RPM_PACKAGES_NAME="['yum-add-gitlab','gitlab-buildpkg-tools']"
 
     # - MOLECULE_DISTRO=centos8
     #   CI_PROJECT_NAME=gitlab-buildpkg-tools
-    #   CI_PAGES_URL=http://orange-opensource.gitlab.io
+    #   CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
     #   RPM_PACKAGES_NAME="['yum-add-gitlab','gitlab-buildpkg-tools']"
 
     # Test additional
@@ -45,22 +45,22 @@ env:
     - MOLECULE_DISTRO=debian9
       MOLECULE_PLAYBOOK=playbook-ppa-and-additional.yml
       CI_PROJECT_NAME=gitlab-buildpkg-tools
-      CI_PAGES_URL=http://orange-opensource.gitlab.io
+      CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
 
     - MOLECULE_DISTRO=debian10
       MOLECULE_PLAYBOOK=playbook-ppa-and-additional.yml
       CI_PROJECT_NAME=gitlab-buildpkg-tools
-      CI_PAGES_URL=http://orange-opensource.gitlab.io
+      CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
 
     - MOLECULE_DISTRO=centos7
       MOLECULE_PLAYBOOK=playbook-ppa-and-additional.yml
       CI_PROJECT_NAME=gitlab-buildpkg-tools
-      CI_PAGES_URL=http://orange-opensource.gitlab.io
+      CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
 
     # - MOLECULE_DISTRO=centos8
     #   MOLECULE_PLAYBOOK=playbook-ppa-and-additional.yml
     #   CI_PROJECT_NAME=gitlab-buildpkg-tools
-    #   CI_PAGES_URL=http://orange-opensource.gitlab.io
+    #   CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
 
 install:
   # Install test dependencies.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,27 @@ This role can't be completely test in a GitLab CI pipeline because we want to
 use predefined environment variables that can't be overriden (`CI_PAGES_URL`
 and `CI_PROJECT_NAME`). For this reason, we use Travis CI to test this role.
 
+### Local tests ###
+
+Prerequisites:
+- molecule[docker]
+- ansible
+- docker
+
+Examples:
+```shell
+$ MOLECULE_DISTRO=debian10 \
+CI_PROJECT_NAME=gitlab-buildpkg-tools \
+CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools \
+MOLECULE_PLAYBOOK=playbook-ppa-and-additional.yml molecule test
+
+$ MOLECULE_DISTRO=centos7 \
+CI_PROJECT_NAME=gitlab-buildpkg-tools \
+CI_PAGES_URL=http://orange-opensource.gitlab.io/gitlab-buildpkg-tools \
+MOLECULE_PLAYBOOK=playbook-ppa-and-additional.yml molecule test
+```
+
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ variables:
   DEB_PACKAGES_NAME: "['apt-add-gitlab', 'gitlab-buildpkg-tools']"
   RPM_PACKAGES_NAME: "['yum-add-gitlab', 'gitlab-buildpkg-tools']"
   CI_PROJECT_NAME: gitlab-buildpkg-tools
-  CI_PAGES_URL: http://orange-opensource.gitlab.io
+  CI_PAGES_URL: http://orange-opensource.gitlab.io/gitlab-buildpkg-tools
 ```
 
 Of course, if you use this playbook inside a pipeline where
@@ -151,7 +151,7 @@ Test of this role
 -----------------
 
 This role can't be completely test in a GitLab CI pipeline because we want to
-use predefined environment variables that can't be overrided (`CI_PAGES_URL`
+use predefined environment variables that can't be overriden (`CI_PAGES_URL`
 and `CI_PROJECT_NAME`). For this reason, we use Travis CI to test this role.
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 gitlab_buildpkg_tools__ppa_enabled: '{{ True if lookup("env", "CI_PAGES_URL")
                                              else False }}'
 
-gitlab_buildpkg_tools__ppa_url: '{{ lookup("env", "CI_PAGES_URL") + "/" + lookup("env", "CI_PROJECT_NAME") }}'
+gitlab_buildpkg_tools__ppa_url: '{{ lookup("env", "CI_PAGES_URL") }}'
 gitlab_buildpkg_tools__ppa_url_deb: '{{ gitlab_buildpkg_tools__ppa_url + "/debian" }}'
 gitlab_buildpkg_tools__ppa_url_rpm: '{{ gitlab_buildpkg_tools__ppa_url + "/centos" }}'
 


### PR DESCRIPTION
`CI_PAGES_URL` already contains `CI_PROJECT_NAME`.

Example of a `CI_PAGES_URL` variable: `https://inverse-inc.gitlab.io/perl-client`