### PR TITLE
Feature/rhel8 and debian11

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,6 +3,7 @@
   apt:
     name: "{{ gitlab_buildpkg_tools__deb_deps_pkgs }}"
     state: present
+    update_cache: yes
 
 - name: add public keys
   apt_key:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -21,6 +21,7 @@
     skip_if_unavailable: no
     repo_gpgcheck: no
     priority: "{{ item['priority'] | d(omit) }}"
+    modules_hotfixes: "{{ item['module_hotfixes'] | d(omit) }}"
   loop: "{{ gitlab_buildpkg_tools__rpm_combined_repos }}"
   loop_control:
     label: "{{ item['name'] }}"


### PR DESCRIPTION
- Debian 11: need to update cache before starting installating packages
- RHEL8: need to enable option `module_hotfixes` to make packages available from packetfence repository (see https://www.man7.org/linux/man-pages/man7/dnf.modularity.7.html, sections "PACKAGE FILTERING" and "HOTFIX REPOSITORIES"

`module_hotfixes` is only available with ansible-core 2.11
