### PR TITLE
add retries to tasks which need Internet access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.4] - 2022-12-05
+### Added
+- Retry tasks which need Internet access until success
 
 ## [1.3.3] - 2022-02-01
 ### Added

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -4,12 +4,20 @@
     name: "{{ gitlab_buildpkg_tools__deb_deps_pkgs }}"
     state: "{{ gitlab_buildpkg_tools__deb_deps_pkgs_state }}"
     update_cache: yes
+  register: reg_install_deb_dep_from_repos
+  retries: 5
+  delay: 10
+  until: reg_install_deb_dep_from_repos is succeeded
 
 - name: add public keys
   apt_key:
     url: "{{ item }}"
     state: present
   loop: '{{ gitlab_buildpkg_tools__deb_combined_keys }}'
+  register: reg_install_deb_keys_repos
+  retries: 5
+  delay: 10
+  until: reg_install_deb_keys is succeeded
 
 - name: install repos
   template:
@@ -25,3 +33,7 @@
     name: "{{ gitlab_buildpkg_tools__deb_pkgs }}"
     update_cache: yes
     state: "{{ gitlab_buildpkg_tools__deb_pkgs_state }}"
+  register: reg_install_deb_pkg_from_repos
+  retries: 5
+  delay: 10
+  until: reg_install_deb_pkg_from_repos is succeeded

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -3,12 +3,20 @@
   yum:
     name: "{{ gitlab_buildpkg_tools__rpm_deps_pkgs }}"
     state: "{{ gitlab_buildpkg_tools__rpm_deps_pkgs_state }}"
+  register: reg_install_rpm_dep_from_repos
+  retries: 5
+  delay: 10
+  until: reg_install_rpm_dep_from_repos is succeeded
 
 - name: add public keys
   rpm_key:
     key: "{{ item }}"
     state: present
   loop: "{{ gitlab_buildpkg_tools__rpm_combined_keys }}"
+  register: reg_install_rpm_keys_repos
+  retries: 5
+  delay: 10
+  until: reg_install_rpm_keys is succeeded
 
 - name: install repos
   template:
@@ -35,3 +43,7 @@
     name: "{{ gitlab_buildpkg_tools__rpm_pkgs }}"
     update_cache: yes
     state: "{{ gitlab_buildpkg_tools__rpm_pkgs_state }}"
+  register: reg_install_rpm_pkg_from_repos
+  retries: 5
+  delay: 10
+  until: reg_install_rpm_pkg_from_repos is succeeded

--- a/tasks/rocky.yml
+++ b/tasks/rocky.yml
@@ -3,12 +3,20 @@
   yum:
     name: "{{ gitlab_buildpkg_tools__rpm_deps_pkgs }}"
     state: "{{ gitlab_buildpkg_tools__rpm_deps_pkgs_state }}"
+  register: reg_install_rpm_dep_from_repos
+  retries: 5
+  delay: 10
+  until: reg_install_rpm_dep_from_repos is succeeded
 
 - name: add public keys
   rpm_key:
     key: "{{ item }}"
     state: present
   loop: "{{ gitlab_buildpkg_tools__rpm_combined_keys }}"
+  register: reg_install_rpm_keys_repos
+  retries: 5
+  delay: 10
+  until: reg_install_rpm_keys is succeeded
 
 - name: install repos
   template:
@@ -35,3 +43,7 @@
     name: "{{ gitlab_buildpkg_tools__rpm_pkgs }}"
     update_cache: yes
     state: "{{ gitlab_buildpkg_tools__rpm_pkgs_state }}"
+  register: reg_install_rpm_pkg_from_repos
+  retries: 5
+  delay: 10
+  until: reg_install_rpm_pkg_from_repos is succeeded


### PR DESCRIPTION
This will let more time to our CI VM to get an IP in DHCP in order to reach external ressources.